### PR TITLE
Add 'class' methods to LibC::GUID

### DIFF
--- a/src/winmd/ecr/library_main.ecr
+++ b/src/winmd/ecr/library_main.ecr
@@ -3,3 +3,12 @@ require "./<%= WinMD.top_level_namespace.downcase %>/com_ptr"
 module <%= WinMD.top_level_namespace %>
   VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
 end
+
+struct LibC::GUID
+  def to_s
+    sprintf("%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", @data1, @data2, @data3, @data4[0], @data4[1], @data4[2], @data4[3], @data4[4], @data4[5], @data4[6], @data4[7])
+  end
+  def to_clsid
+    sprintf("{%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}", @data1, @data2, @data3, @data4[0], @data4[1], @data4[2], @data4[3], @data4[4], @data4[5], @data4[6], @data4[7])
+  end
+end


### PR DESCRIPTION
The two functions help out in comparison by converting the GUID into a more readable string for regular and CLSID.