### PR TITLE
Updated fixing type names

### DIFF
--- a/src/winmd.cr
+++ b/src/winmd.cr
@@ -106,6 +106,7 @@ module WinMD
     name = name.sub(/^tag/, "")
     while /^_/.match(name)
       name = name.sub(/^_/, "")
+      name += "_"
     end
     unless name[0].uppercase?
       name = name.capitalize


### PR DESCRIPTION
Before this change, if there was preceding underscores they were just removed. Now, if there are preceding underscores, they are kept and a single underscore is added at the end. This should prevent duplicate type names that are conflicting.