### PR TITLE
Function Pointer rendering fix

### DIFF
--- a/src/winmd/ecr/function_pointer.ecr
+++ b/src/winmd/ecr/function_pointer.ecr
@@ -1,7 +1,7 @@
 <% if architectures? -%>
 <%= pad %>{% if <%= render_arches.join(" || ") %> %}
 <% end -%>
-<%= pad %>alias <%= @name %> = Proc(<% if @params.any? %><%= @params.map { |x| x.type.render }.join(", ") %>, <% end %><%= @return_type.render %>)*
+<%= pad %>alias <%= @name %> = Proc(<% if @params.any? %><%= @params.map { |x| x.type.render }.join(", ") %>, <% end %><%= @return_type.render %>)
 <% if architectures? -%>
 <%= pad %>{% end %}
 <% end -%>


### PR DESCRIPTION
Function Pointers were being originally rendered as a pointer type, which is incorrect because contrary to what the name suggests, they are not standard pointers but a variable that holds the address of a function.