### PR TITLE
Updated structs and com templates

### DIFF
--- a/src/winmd/ecr/com.ecr
+++ b/src/winmd/ecr/com.ecr
@@ -16,7 +16,6 @@
 
 <%= pad %>@[Extern]
 <% if @guid -%>
-<%= pad %>#@[Com("<%= @guid %>")]
 <% end -%>
 <%= pad %>record <%= @name %>, lpVtbl : <%= @name %>Vtbl* do
 <% if my_guid = get_guid -%>

--- a/src/winmd/ecr/struct.ecr
+++ b/src/winmd/ecr/struct.ecr
@@ -2,9 +2,9 @@
 <%= pad %>{% if <%= render_arches.join(" || ") %> %}
 <% end -%>
 <%= pad %>@[Extern<% if is_union? %>(union: true)<% end %>]
-<%= pad %>record <%= @name %><% if @fields.any? %>,
+<%= pad %>struct <%= @name %>
 <%- @fields.each do |f| -%>
-<%= f.pad %><%= f.render %><% if @fields.last != f %>,<% else %><% if @nested_types.any? %> do<% end %><% end %>
+<%= f.pad(4) %>property <%= f.render %>
 <%- end -%>
 <% if @nested_types.any? -%>
 <% @nested_types.each do |t| -%>
@@ -12,9 +12,10 @@
 <%= t.pad %># Nested Type <%= t.as(WinMD::Type::Struct).name %>
 <%= t.render %>
 <% end -%>
+<% end -%>
+<%= pad(4) %>def initialize(<%= @fields.map { |f| "@" + f.render }.join(", ") %>)
+<%= pad(4) %>end
 <%= pad %>end
-<% end -%>
-<% end -%>
 <% if architectures? -%>
 <%= pad %>{% end %}
 <% end -%>


### PR DESCRIPTION
Struct template was updated to not use the `record` macro because fields in the struct are not properties when using `record`. This was changed to use `struct` instead.

Com template was updated to remove a commented out annotation that isnt being used.