### PR TITLE
Overrides and Wrappers

### DIFF
--- a/src/winmd/cli/generate.cr
+++ b/src/winmd/cli/generate.cr
@@ -86,7 +86,9 @@ module WinMD
           WinMD.process_json_files(json_path)
           Log.debug { "Phase 2 - Resolving COM Interfaces" }
           WinMD.resolve_com_interfaces
-          Log.debug { "Phase 3 - Writing Files" }
+          Log.debug { "Phase 3 - Applying Overrides" }
+          WinMD.apply_overrides
+          Log.debug { "Phase 4 - Writing Files" }
           WinMD.write_files(dst)
         end
         Log.debug { "Total time taken #{elapsed_time}" }

--- a/src/winmd/ecr/enum_value.ecr
+++ b/src/winmd/ecr/enum_value.ecr
@@ -1,1 +1,1 @@
-<%= @name %> = <%= @value %>_<%= integer_base %>
+<% if @override_name.empty? %><%= @name %><% else %><%= @override_name %><% end %> = <% if @override_value.empty? %><%= @value %><% else %><%= @override_value %><% end %>_<%= integer_base %>

--- a/src/winmd/ecr/file.ecr
+++ b/src/winmd/ecr/file.ecr
@@ -4,6 +4,7 @@
 <% end -%>
 <% end %>
 module <%= @namespace %>
+  extend self
 <% @types.map { |x| x if x.is_a?(WinMD::Type::NativeTypedef) }.compact.each do |t| -%>
 <%= t.render %>
 <% end -%>
@@ -27,6 +28,9 @@ module <%= @namespace %>
 <%= t.render %>
 <% end -%>
 <% if @functions.any? -%>
+<% @functions.each do |f| -%>
+<%= f.wrapper_render %>
+<% end -%>
 <% @links.each do |l| -%>
   @[Link("<%= l %>")]
 <% end -%>

--- a/src/winmd/ecr/function.ecr
+++ b/src/winmd/ecr/function.ecr
@@ -4,7 +4,8 @@
 <% if @libc_fun -%>
 <%= pad(4) %># Commented out due to being part of LibC
 <% end -%>
-<%= pad(4) %><% if @libc_fun %>#<% end %>fun <%= @name %><% if @params.any? %>(<%= @params.map { |p| p.render }.join(", ") %>)<% end %> : <%= @return_type.render %>
+<%= pad(4) %># :nodoc:
+<%= pad(4) %><% if @libc_fun %>#<% end %>fun <% if WinMD.fun_aliases? %><% if @fun_alias.empty? %><%= @name.underscore %><% else %><%= @fun_alias %><% end %> = <% end %><% if @override_name.empty? %><%= @name %><% else %><%= @override_name %><% end %><% if @params.any? %>(<%= @params.map { |p| p.render }.join(", ") %>)<% end %> : <% if @override_return_type.empty? %><%= @return_type.render %><% else %><%= @override_return_type %><% end %>
 <% if architectures? -%>
-<%= pad %>{% end %}
+<%= pad(4) %>{% end %}
 <% end -%>

--- a/src/winmd/ecr/function_wrapper.ecr
+++ b/src/winmd/ecr/function_wrapper.ecr
@@ -1,0 +1,9 @@
+<% if architectures? -%>
+{% if <%= render_arches.join(" || ") %> %}
+<% end -%>
+<%= pad %><% if @libc_fun %>#<% end %>def <% if @override_name.empty? %><%= @name.camelcase(lower: true) %><% else %><%= @override_name.camelcase(lower: true) %><% end %><% if @params.any? %>(<%= @params.map { |p| p.render }.join(", ") %>)<% end %> : <% if @override_return_type.empty? %><%= @return_type.render %><% else %><%= @override_return_type %><% end %>
+<%= pad(4) %><% if @libc_fun %>#<% end %>C.<% if @override_name.empty? %><%= @name.camelcase(lower: true) %><% else %><%= @override_name.camelcase(lower: true) %><% end %><% if @params.any? %>(<%= @params.map { |p| p.name }.join(", ") %>)<% end %>
+<%= pad %><% if @libc_fun %>#<% end %>end
+<% if architectures? -%>
+{% end %}
+<% end -%>

--- a/src/winmd/ecr/param.ecr
+++ b/src/winmd/ecr/param.ecr
@@ -1,1 +1,1 @@
-<%= @name %> : <%= @type.render %><% if @type.pointer? %>*<% end %>
+<%= @override_name.empty? ? @name : @override_name %> : <% if @override_type.empty? %><%= @type.render %><% if @type.pointer? %>*<% end %><% else %><%= @override_type %><% end %>

--- a/src/winmd/ecr/struct.ecr
+++ b/src/winmd/ecr/struct.ecr
@@ -2,7 +2,7 @@
 <%= pad %>{% if <%= render_arches.join(" || ") %> %}
 <% end -%>
 <%= pad %>@[Extern<% if is_union? %>(union: true)<% end %>]
-<%= pad %>struct <%= @name %>
+<%= pad %>struct <% if @override_name.empty? %><%= @name %><% else %><%= @override_name %><% end %>
 <%- @fields.each do |f| -%>
 <%= f.pad(4) %>property <%= f.render %>
 <%- end -%>

--- a/src/winmd/ecr/struct_field.ecr
+++ b/src/winmd/ecr/struct_field.ecr
@@ -1,1 +1,1 @@
-<%= @name %> : <%= @type.render %><% if @type.pointer? %>*<% end %>
+<% if @override_name.empty? %><%= @name %><% else %><%= @override_name %><% end %> : <% if @override_name.empty? %><%= @type.render %><% if @type.pointer? %>*<% end %><% else %><%= @override_type %><% end %>

--- a/src/winmd/fun_override.cr
+++ b/src/winmd/fun_override.cr
@@ -1,0 +1,143 @@
+module WinMD
+  @[JSON::Serializable::Options(presence: true, emit_nulls: true)]
+  class FunOverride
+    include JSON::Serializable
+    include JSON::Serializable::Unmapped
+
+    @@overrides = [] of FunOverride
+
+    enum Type
+      Function
+      Enum
+      Struct
+    end
+
+    @[JSON::Serializable::Options(presence: true, emit_nulls: true)]
+    class Rule
+      include JSON::Serializable
+      include JSON::Serializable::Unmapped
+
+      enum Type
+        FunName          # Function Name
+        FunAlias         # Function Alias (e.g. `fun alias_name = function_name)
+        ReturnType       # Fun return type
+        ParamName        # Parameter Name
+        ParamType        # Parameter Data Type
+        EnumName         # Enum Name
+        EnumMemberName   # Enum Member Name
+        EnumMemberValue  # Enum Integer Base Type
+        StructName       # Struct Name
+        StructFieldName  # Struct Field Name
+        StructFieldType  # Struct Field Type
+      end
+
+      @[JSON::Field]
+      property description : String # Rule description
+
+      @[JSON::Field]
+      property type : Type # Rule type
+
+      @[JSON::Field]
+      property index : Int32 = 0 # Index of the parameter to override
+
+      @[JSON::Field]
+      property key : String = "" # Key (if used)
+
+      @[JSON::Field]
+      property value : String # Value to override with
+
+      def after_initialize
+      end
+
+      def type_name?
+        @type == Type::Name
+      end
+
+      def type_alias?
+        @type == Type::Alias
+      end
+
+      def param_name?
+        @type == Type::ParamName
+      end
+
+      def param_type?
+        @type == Type::ParamType
+      end
+
+      def enum_type?
+        @type == Type::EnumType
+      end
+
+      def enum_value?
+        @type == Type::EnumValue
+      end
+
+      def struct_field_name?
+        @type == Type::StructFieldName
+      end
+
+      def struct_field_type?
+        @type == Type::StructFieldType
+      end
+    end
+
+    @[JSON::Field(ignore: false)]
+    property name : String # Name of the function to override
+
+    @[JSON::Field(ignore: false)]
+    property namespace : String # Namespace of the function to override
+
+    @[JSON::Field(ignore: false)]
+    property type : Type # Data Type override applies to
+
+    @[JSON::Field(ignore: false)] 
+    property rule : Rule # The Rule
+
+    def self.add_override(override : FunOverride)
+      @@overrides << override
+    end
+
+    def self.overrides
+      @@overrides
+    end
+
+    def self.load_overrides(file : Path)
+      if ::File.exists?(file)
+        begin
+          json = JSON.parse(::File.read(file))
+          json.as_a.each do |x|
+            override = FunOverride.from_json(x.to_json)
+            add_override(override)
+            Log.debug { "Loaded override: #{override.name} : #{override.type} -> Rule type #{override.rule.type}" }
+          end
+        rescue e : JSON::SerializableError
+          Log.fatal { "Failed to load overrides" }
+          Log.fatal { e.message }
+          exit 1
+        end
+      end
+    end
+
+    def self.find_ns_overrides(namespace : String) : Array(FunOverride)
+      Log.debug { "Searching for overrides in namespace: #{namespace}" }
+      resp = @@overrides.select { |x| x.namespace == namespace }
+      Log.trace { "Overrides found: #{resp.inspect}"}
+      Log.debug { "Total overrides found: #{resp.size}"}
+      resp
+    end
+
+    def self.find_overrides(name : String, namespace : String, type : Type) : Array(FunOverride)
+      Log.debug { "Searching for overrides: #{name} in #{namespace}" }
+      resp = @@overrides.select { |x| x.name == name && x.namespace == namespace && x.type == type }
+      Log.trace { "Overrides found: #{resp.inspect}"}
+      Log.debug { "Total overrides found: #{resp.size}"}
+      resp
+    end
+
+    delegate :type_name?, to: @rule
+    delegate :type_alias?, to: @rule
+    delegate :param_name?, to: @rule
+    delegate :param_type?, to: @rule
+  end
+end

--- a/src/winmd/template/file.cr
+++ b/src/winmd/template/file.cr
@@ -55,6 +55,10 @@ class WinMD::File < WinMD::Base
     qualified_path == other.qualified_path
   end
 
+  def enums
+    @types.select(WinMD::Type::Enum)
+  end
+
   def native_typedefs
     @types.select(WinMD::Type::NativeTypedef)
   end
@@ -163,7 +167,12 @@ class WinMD::File < WinMD::Base
     end
   end
 
-
+  def process_overrides
+    Log.debug { "{File}Applying overrides for #{@namespace} - #{@file_name}" }
+    @functions.each(&.apply_overrides)
+    structs_and_unions.each(&.apply_overrides)
+    enums.each(&.apply_overrides)
+  end
 
   def self.from_json(json_data, filename)
     file = from_json(json_data)

--- a/src/winmd/template/function.cr
+++ b/src/winmd/template/function.cr
@@ -31,6 +31,14 @@ class WinMD::Function < WinMD::Base
   @[JSON::Field(ignore: true)]
   getter libc_fun : Bool = false
 
+  @[JSON::Field(ignore: true)]
+  getter fun_alias : String = ""
+
+  @[JSON::Field(ignore: true)]
+  getter override_name : String = ""
+
+  @[JSON::Field(ignore: true)]
+  getter override_return_type : String = ""
 
   def after_initialize
     super
@@ -38,6 +46,39 @@ class WinMD::Function < WinMD::Base
       @libc_fun = true
     end
     @dll_import = @dll_import.downcase
+    @fun_alias = @name.underscore
+  end
+
+  def apply_overrides
+    Log.debug { "Checking for overrides for #{@name} in namespace #{@file.not_nil!.namespace}" }
+    overrides = WinMD::FunOverride.find_overrides(@name, @file.not_nil!.namespace, WinMD::FunOverride::Type::Function)
+    Log.debug { "Applying #{overrides.size} overrides for #{@name}" }
+    apply_overrides(overrides)
+  end
+
+  def apply_overrides(overrides : Array(WinMD::FunOverride))
+    overrides.each do |override|
+      Log.trace { "Applying override rule type #{override.rule.type} for function #{@name}" }
+      case override.rule.type
+      when WinMD::FunOverride::Rule::Type::FunName
+        Log.trace { "Applying name override for #{@name} -> #{override.rule.value}" }
+        if override.rule.key == @name
+          @name = override.rule.value
+        end
+      when WinMD::FunOverride::Rule::Type::FunAlias
+        Log.trace { "Applying alias override for #{@name} -> #{override.rule.value}" }
+        @fun_alias = override.rule.value
+      when WinMD::FunOverride::Rule::Type::ParamName
+        Log.trace { "Applying param name override for #{@name} -> #{override.rule.value}" }
+        @params[override.rule.index].override_name = override.rule.value
+      when WinMD::FunOverride::Rule::Type::ParamType
+        Log.trace { "Applying param type override for #{@name} -> #{override.rule.value}" }
+        @params[override.rule.index].override_type = override.rule.value
+      when WinMD::FunOverride::Rule::Type::ReturnType
+        Log.trace { "Applying return type override for #{@name} -> #{override.rule.value}" }
+        @override_return_type = override.rule.value
+      end
+    end
   end
 
   def file=(file : WinMD::File)
@@ -48,5 +89,9 @@ class WinMD::Function < WinMD::Base
 
   def render
     ECR.render "./src/winmd/ecr/function.ecr"
+  end
+
+  def wrapper_render
+    ECR.render "./src/winmd/ecr/function_wrapper.ecr"
   end
 end

--- a/src/winmd/template/param.cr
+++ b/src/winmd/template/param.cr
@@ -9,6 +9,12 @@ class WinMD::Param < WinMD::Base
   @[JSON::Field(key: "Attrs")]
   property attrs = [] of String | WinMD::Type
 
+  @[JSON::Field(ignore: true)]
+  property override_type : String = ""
+
+  @[JSON::Field(ignore: true)]
+  property override_name : String = ""
+
   def after_initialize
     super
     @name = WinMD.fix_param_name(@name)

--- a/src/winmd/template/type.cr
+++ b/src/winmd/template/type.cr
@@ -19,6 +19,12 @@ abstract class WinMD::Type < WinMD::Base
     true
   end
 
+  def apply_overrides
+  end
+
+  def apply_overrides(overrides = [] of WinMD::FunOverride)
+  end
+
   def file=(file : WinMD::File)
     super(file)
   end

--- a/src/winmd/template/type/enum_member.cr
+++ b/src/winmd/template/type/enum_member.cr
@@ -9,6 +9,11 @@ class WinMD::Type::Enum::EnumMember < WinMD::Base
   @[JSON::Field(ignore: true)]
   property parent : WinMD::Type::Enum?
 
+  @[JSON::Field(ignore: true)]
+  property override_name : String = ""
+
+  @[JSON::Field(ignore: true)]
+  property override_value : String = ""
 
   def after_initialize
     @name = WinMD.fix_type_name(@name)

--- a/src/winmd/template/type/struct_field.cr
+++ b/src/winmd/template/type/struct_field.cr
@@ -9,6 +9,12 @@ class WinMD::Type::Struct::StructField < WinMD::Base
   @[JSON::Field(key: "Attrs")]
   property attrs = [] of String
 
+  @[JSON::Field(ignore: true)]
+  property override_name : String = ""
+
+  @[JSON::Field(ignore: true)]
+  property override_type : String = ""
+
   def after_initialize
     @name = WinMD.fix_param_name(@name)
     super


### PR DESCRIPTION
Added overrides that allow rules to be applied to change names, params, etc. This was necessary as some functions have params that are typed with an Enum but really need to be an integer value.

Added in function wrappers methods to wrap the C funs. This doesnt simplify calls to the funs but it does make it possible to call them without having to specify the `C` library namespace.