### PR TITLE
Fix for empty structs, crystal docs, com vtables

### DIFF
--- a/src/winmd/ecr/com.ecr
+++ b/src/winmd/ecr/com.ecr
@@ -2,7 +2,7 @@
 <%= pad %>{% if <%= render_arches.join(" || ") %> %}
 <% end -%>
 <%= pad %>@[Extern]
-<%= pad %>record <%= @name %>Vtbl,
+<%= pad %>record <%= @name %>Vtable,
 <% resolve_methods.each do |x| -%>
 <% if x.architectures? -%>
 <%= pad(4) %>{% if <%= x.render_arches %> %}
@@ -17,7 +17,7 @@
 <%= pad %>@[Extern]
 <% if @guid -%>
 <% end -%>
-<%= pad %>record <%= @name %>, lpVtbl : <%= @name %>Vtbl* do
+<%= pad %>record <%= @name %>, lpVtbl : <%= @name %>Vtable* do
 <% if my_guid = get_guid -%>
 <%= pad(4) %>GUID = LibC::GUID.new(<%= my_guid.to_hex_params %>)
 <% end -%>

--- a/src/winmd/ecr/file.ecr
+++ b/src/winmd/ecr/file.ecr
@@ -34,10 +34,12 @@ module <%= @namespace %>
 <% @links.each do |l| -%>
   @[Link("<%= l %>")]
 <% end -%>
+  {% if !flag?(:docs) %}
   lib C
 <% @functions.each do |f| -%>
 <%= f.render %>
 <% end -%>
   end
+  {% end %}
 <% end -%>
 end

--- a/src/winmd/ecr/function_wrapper.ecr
+++ b/src/winmd/ecr/function_wrapper.ecr
@@ -2,7 +2,13 @@
 {% if <%= render_arches.join(" || ") %> %}
 <% end -%>
 <%= pad %><% if @libc_fun %>#<% end %>def <% if @override_name.empty? %><%= @name.camelcase(lower: true) %><% else %><%= @override_name.camelcase(lower: true) %><% end %><% if @params.any? %>(<%= @params.map { |p| p.render }.join(", ") %>)<% end %> : <% if @override_return_type.empty? %><%= @return_type.render %><% else %><%= @override_return_type %><% end %>
+<% unless @libc_fun -%>
+<%= pad(4) %>{% if !flag?(:docs) %}
+<% end -%>
 <%= pad(4) %><% if @libc_fun %>#<% end %>C.<% if @override_name.empty? %><%= @name %><% else %><%= @override_name %><% end %><% if @params.any? %>(<%= @params.map { |p| p.name }.join(", ") %>)<% end %>
+<% unless @libc_fun -%>
+<%= pad(4) %>{% end %}
+<% end -%>
 <%= pad %><% if @libc_fun %>#<% end %>end
 <% if architectures? -%>
 {% end %}

--- a/src/winmd/ecr/struct.ecr
+++ b/src/winmd/ecr/struct.ecr
@@ -1,6 +1,9 @@
 <% if architectures? -%>
 <%= pad %>{% if <%= render_arches.join(" || ") %> %}
 <% end -%>
+<% if @fields.empty? && @nested_types.empty? -%>
+<%= pad %>alias <%= @name %> = Void
+<% else -%>
 <%= pad %>@[Extern<% if is_union? %>(union: true)<% end %>]
 <%= pad %>struct <% if @override_name.empty? %><%= @name %><% else %><%= @override_name %><% end %>
 <%- @fields.each do |f| -%>
@@ -16,6 +19,7 @@
 <%= pad(4) %>def initialize(<%= @fields.map { |f| "@" + f.render }.join(", ") %>)
 <%= pad(4) %>end
 <%= pad %>end
+<% end -%>
 <% if architectures? -%>
 <%= pad %>{% end %}
 <% end -%>


### PR DESCRIPTION
Empty structs are turned into aliases to `Void`

Wrap the `lib` definition in a conditional to prevent it from being included in the docs because of the way crystal docs operates. This is a temporary fix until a better solution is found.

Renamed the vtables for com objects to avoid name conflicts with other types.