### PR TITLE
Ignore attrs in JSON deserialization

### DIFF
--- a/src/winmd/template/base.cr
+++ b/src/winmd/template/base.cr
@@ -15,6 +15,8 @@ abstract class WinMD::Base
   @[JSON::Field(ignore: true)]
   property? pointer : Bool = false
 
+  @[JSON::Field(key: "Attrs", ignore_deserialize: true)]
+  property attrs : JSON::Any? = nil
 
   def after_initialize
   end

--- a/src/winmd/template/constant.cr
+++ b/src/winmd/template/constant.cr
@@ -12,9 +12,6 @@ class WinMD::Constant < WinMD::Base
   @[JSON::Field(key: "Value", converter: String::RawConverter)]
   property value : String
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   def after_initialize
     @name = WinMD.fix_type_name(@name)
     case @valuetype

--- a/src/winmd/template/function.cr
+++ b/src/winmd/template/function.cr
@@ -22,9 +22,6 @@ class WinMD::Function < WinMD::Base
   @[JSON::Field(key: "ReturnAttrs")]
   property return_attrs = [] of String
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   @[JSON::Field(key: "Params")]
   property params = [] of WinMD::Param
 

--- a/src/winmd/template/method.cr
+++ b/src/winmd/template/method.cr
@@ -19,9 +19,6 @@ class WinMD::Method < WinMD::Base
   @[JSON::Field(key: "ReturnAttrs")]
   property return_attrs = [] of String
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   @[JSON::Field(key: "Params")]
   property params = [] of WinMD::Param
 

--- a/src/winmd/template/param.cr
+++ b/src/winmd/template/param.cr
@@ -6,9 +6,6 @@ class WinMD::Param < WinMD::Base
   @[JSON::Field(key: "Type")]
   property type : WinMD::Type
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String | WinMD::Type
-
   @[JSON::Field(ignore: true)]
   property override_type : String = ""
 

--- a/src/winmd/template/type/com.cr
+++ b/src/winmd/template/type/com.cr
@@ -13,9 +13,6 @@ class WinMD::Type::Com < WinMD::Type
   @[JSON::Field(key: "Guid")]
   property guid : String | Nil
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   @[JSON::Field(key: "Methods")]
   property methods = [] of WinMD::Method
 

--- a/src/winmd/template/type/function_pointer.cr
+++ b/src/winmd/template/type/function_pointer.cr
@@ -19,9 +19,6 @@ class WinMD::Type::FunctionPointer < WinMD::Type
   @[JSON::Field(key: "ReturnAttrs")]
   property return_attrs = [] of String
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   @[JSON::Field(key: "Params")]
   property params = [] of WinMD::Param
 

--- a/src/winmd/template/type/return_type.cr
+++ b/src/winmd/template/type/return_type.cr
@@ -3,9 +3,6 @@ class WinMD::Type::ReturnType < WinMD::Type
   @[JSON::Field(key: "Name")]
   property name : String?
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   @[JSON::Field(key: "TargetKind")]
   property target_kind : String?
 

--- a/src/winmd/template/type/struct.cr
+++ b/src/winmd/template/type/struct.cr
@@ -19,9 +19,6 @@ class WinMD::Type::Struct < WinMD::Type
   @[JSON::Field(key: "Fields")]
   property fields = [] of WinMD::Type::Struct::StructField
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
-
   @[JSON::Field(key: "NestedTypes")]
   property nested_types = [] of WinMD::Type
 

--- a/src/winmd/template/type/struct_field.cr
+++ b/src/winmd/template/type/struct_field.cr
@@ -6,8 +6,7 @@ class WinMD::Type::Struct::StructField < WinMD::Base
   @[JSON::Field(key: "Type")]
   property type : WinMD::Type
 
-  @[JSON::Field(key: "Attrs")]
-  property attrs = [] of String
+
 
   @[JSON::Field(ignore: true)]
   property override_name : String = ""


### PR DESCRIPTION
The Attrs field is not used in the deserialization process anymore since it is not used.