### PR TITLE
Run CI tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: winmd.cr CI
+name: CI Testing
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   spec:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Workflow is meant to run on Windows not Ubuntu.